### PR TITLE
fix number of namelti.ConvertName argument

### DIFF
--- a/src/exec/namelti_cli.cc
+++ b/src/exec/namelti_cli.cc
@@ -33,7 +33,8 @@ int main(int argc, char* argv[]) {
             else if(query.empty()){
                 continue;
             }
-            std::vector<std::pair<std::string, float>> results = namelti.ConvertName(query);
+            size_t maxResults = 10;
+            std::vector<std::pair<std::string, float>> results = namelti.ConvertName(query, maxResults);
             if(!results.empty()){
               //std::cout << it->first << " => " << "\n";
               for (std::pair<std::string, float>& result : results) {


### PR DESCRIPTION
CentOS7のdockerコンテナ上でnameltiのインストール時に以下のエラーが発生したため、コードを修正しました。

```
# make
g++ -Wall -Wextra -O3 -std=c++11 -isystem../../include -I.. -c namelti_cli.cc
namelti_cli.cc: In function 'int main(int, char**)':
namelti_cli.cc:36:91: error: no matching function for call to 'namelti::NameltiProcessor::ConvertName(std::string&)'
             std::vector<std::pair<std::string, float>> results = namelti.ConvertName(query);
                                                                                           ^
namelti_cli.cc:36:91: note: candidate is:
In file included from namelti_cli.cc:22:0:
../namelti_processor.h:32:46: note: std::vector<std::pair<std::basic_string<char>, float> > namelti::NameltiProcessor::ConvertName(std::string, size_t)
   std::vector<std::pair<std::string, float>> ConvertName(std::string, size_t);
                                              ^
../namelti_processor.h:32:46: note:   candidate expects 2 arguments, 1 provided
make: *** [namelti_cli.o] Error 1
```